### PR TITLE
Add test to ensure Rails uniqueness validation works on uuid attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ by default. But it's good to be aware of this in case you're running into
 weirdness.
 
 
+# Known issues
+
+  * With Rails 5.0 in combination with uniqueness validations, ActiveRecord generates a wrong query. The `x` in front of the queried value, which casts the value to the proper data type, is missing.
+
+
 # Contributing
 
 To start coding on `mysql-binuuid-rails`, fork the project, clone it locally

--- a/test/integration/mysql_integration_test.rb
+++ b/test/integration/mysql_integration_test.rb
@@ -35,6 +35,9 @@ describe MyUuidModel do
     ActiveRecord::Base.establish_connection(db_config)
     connection.create_table("my_uuid_models")
     connection.add_column("my_uuid_models", "the_uuid", :binary, limit: 16)
+
+    # Uncomment this line to get logging on stdout
+    # ActiveRecord::Base.logger = Logger.new(STDOUT)
   end
 
   after(:all) do
@@ -48,6 +51,25 @@ describe MyUuidModel do
       my_model = MyUuidModel.new(the_uuid: sample_uuid)
       assert_equal sample_uuid, my_model.the_uuid
       assert_equal sample_uuid, my_model.attributes["the_uuid"]
+    end
+  end
+
+  context "before saving" do
+    describe "rails validation" do
+
+      class MyUuidModelWithValidations < MyUuidModel
+        validates :the_uuid, uniqueness: true
+      end
+
+      it "validates uniqueness" do
+        uuid = sample_uuid
+        MyUuidModelWithValidations.create!(the_uuid: uuid)
+        duplicate = MyUuidModelWithValidations.new(the_uuid: uuid)
+
+        assert_equal false, duplicate.valid?
+        assert_equal :taken, duplicate.errors.details[:the_uuid].first[:error]
+      end
+
     end
   end
 

--- a/test/integration/mysql_integration_test.rb
+++ b/test/integration/mysql_integration_test.rb
@@ -62,6 +62,8 @@ describe MyUuidModel do
       end
 
       it "validates uniqueness" do
+        skip("Skipping uniqueness validation test, known issue on Rails 5.0") if Rails.version < "5.1"
+
         uuid = sample_uuid
         MyUuidModelWithValidations.create!(the_uuid: uuid)
         duplicate = MyUuidModelWithValidations.new(the_uuid: uuid)


### PR DESCRIPTION
I added this test because of a comment in https://github.com/nedap/mysql-binuuid-rails/issues/7#issuecomment-370582717

It turns out that indeed uniqueness validation does not work as expected with Rails 5.0. The uuid attribute is properly serialised but the query is missing the `x` in front of the query which is required to cast the value to the proper data type.

Rails 5.1 is working as intended. 

I will add this as a known issue.

You could consider removing uniqueness validation for uuid columns, since the chance that the same uuid is generated again is practically zero:

> [...] Thus, for there to be a one in a billion chance of duplication, 103 trillion version 4 UUIDs must be generated.
source: https://en.wikipedia.org/wiki/Universally_unique_identifier#Collisions

