### PR TITLE
Update to latest Rubies and add latest Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,8 @@ rvm:
 env:
   matrix:
     - RAILS_VERSION=5.0.5
-    - RAILS_VERSION=5.1.0
-    - RAILS_VERSION=5.1.1
-    - RAILS_VERSION=5.1.2
-    - RAILS_VERSION=5.1.3
-    - RAILS_VERSION=5.1.4
-    - RAILS_VERSION=5.1.5
+    - RAILS_VERSION=5.1.6
+    - RAILS_VERSION=5.2.0
 before_install:
   - gem update bundler
   - bundle update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 env:
   matrix:
     - RAILS_VERSION=5.0.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ env:
     - RAILS_VERSION=5.1.6
     - RAILS_VERSION=5.2.0
 before_install:
+  - gem install bundler
   - gem update bundler
   - bundle update

--- a/mysql-binuuid-rails.gemspec
+++ b/mysql-binuuid-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "mysql2"
+  spec.add_development_dependency "mysql2", "< 0.5"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-spec-context"
   spec.add_development_dependency "minitest-hooks"


### PR DESCRIPTION
`mysql-binuuid-rails` is tested against *all* patch versions of the latest Rails version, and the latest version of the previous Rails minor versions.