### PR TITLE
Bugfix data casting

### DIFF
--- a/lib/mysql-binuuid/type.rb
+++ b/lib/mysql-binuuid/type.rb
@@ -17,7 +17,7 @@ module MySQLBinUUID
         # We cannot unpack something that looks like a UUID, with or without
         # dashes. Not entirely sure why ActiveRecord does a weird combination of
         # cast and serialize before anything needs to be saved..
-        undashed_uuid = value.unpack("H*")[0]
+        undashed_uuid = value.unpack1('H*')
         add_dashes(undashed_uuid.to_s)
       else
         super

--- a/lib/mysql-binuuid/type.rb
+++ b/lib/mysql-binuuid/type.rb
@@ -13,7 +13,7 @@ module MySQLBinUUID
         # It could be a Data object, in which case we should add dashes to the
         # string value from there.
         add_dashes(value.to_s)
-      elsif value.is_a?(String) && value.encoding == Encoding::ASCII_8BIT
+      elsif value.is_a?(String) && value.encoding == Encoding::ASCII_8BIT && strip_dashes(value).length != 32
         # We cannot unpack something that looks like a UUID, with or without
         # dashes. Not entirely sure why ActiveRecord does a weird combination of
         # cast and serialize before anything needs to be saved..

--- a/test/mysql-binuuid/type_test.rb
+++ b/test/mysql-binuuid/type_test.rb
@@ -32,6 +32,13 @@ describe MySQLBinUUID::Type do
     it 'returns the value itself if provided with something else' do
       assert_equal 42, @type.cast(42)
     end
+
+    it 'returns a uuid if provided with a uuid' do
+      uuid = SecureRandom.uuid.encode(Encoding::ASCII_8BIT)
+      data = MySQLBinUUID::Type.new.cast(uuid)
+
+      assert_equal uuid, @type.cast(data)
+    end
   end
 
   describe '#serialize' do


### PR DESCRIPTION
In Rails 5.2, and maybe other versions, cast gets called during the assignment and sometimes is used to attempt to expand a valid UUID. This is to skip casting if the value already looks like a UUID.

I am not sure what tests to add, I only noticed this issue when running my app instance in development and not during any of my normal test coverage. Which is odd because I would expect requests or controller specs to have triggered this issue.