### PR TITLE
Some maintenance updates, CI now runs for Rails 6.0.0 and 6.0.1 too

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 # mysql-binuuid-rails
 
-`mysql-binuuid-rails` leverages the Attributes API of Rails 5 and lets you
-define attributes of type UUID on your models. By doing so, you can store your
-UUIDs as binary values in your database, and still be able to query using
-the string representations since the database will take care of the
-type conversion.
+`mysql-binuuid-rails` lets you define attributes of a UUID type on your models
+by leveraging the Attributes API that has been available since Rails 5. By doing
+so, you can store your UUIDs as binary values in your database, and still be
+able to query using the string representations since the database will take care
+of the type conversion.
 
 As the name suggests, it only supports MySQL. If you're on PostgreSQL, you
 can use UUIDs the proper way already.
@@ -151,6 +151,19 @@ a console with the changes you made, run `bin/console`.
 
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/nedap/mysql-binuuid-rails
+
+## Testing
+
+Continuous integration / automated tests run [on Semaphore](https://semaphoreci.com/nedap-healthcare/mysql-binuuid-rails).
+Tests are run against the latest patch version of every minor ActiveRecord release
+since 5.0, as well as *every* patch version of the latest minor version.
+
+Run tests yourself to verify everything is still working:
+
+```
+$ bundle exec rake
+```
+
 
 ## Contributors
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "rails/all"
+require "active_record/railtie"
 require "mysql-binuuid-rails"
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/mysql-binuuid-rails.gemspec
+++ b/mysql-binuuid-rails.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-spec-context"
   spec.add_development_dependency "minitest-hooks"
+  spec.add_development_dependency "rails", ENV["RAILS_VERSION"] || ">= 5" # required for a console
 end

--- a/test/integration/mysql_integration_test.rb
+++ b/test/integration/mysql_integration_test.rb
@@ -25,7 +25,7 @@ describe MyUuidModel do
 
     # Create a connection without selecting a database first to create the db
     ActiveRecord::Base.establish_connection(db_config_without_db_name)
-    connection.create_database(db_config[:database])
+    connection.create_database(db_config[:database], charset: "utf8mb4")
 
     # Then establish a new connection with the database name
     ActiveRecord::Base.establish_connection(db_config)


### PR DESCRIPTION
This PR:

* Adds CI support for Rails 6
* Makes `bin/console` working again
* Updates the README