### PR TITLE
Do not attempt to serialize blank uuids

### DIFF
--- a/lib/mysql-binuuid/type.rb
+++ b/lib/mysql-binuuid/type.rb
@@ -27,7 +27,7 @@ module MySQLBinUUID
     # Invoked when the provided value needs to be serialized before storing
     # it to the database.
     def serialize(value)
-      return if value.nil?
+      return if value.blank?
       undashed_uuid = strip_dashes(value)
 
       # To avoid SQL injection, verify that it looks like a UUID. ActiveRecord

--- a/test/mysql-binuuid/type_test.rb
+++ b/test/mysql-binuuid/type_test.rb
@@ -44,6 +44,10 @@ describe MySQLBinUUID::Type do
       assert_nil @type.serialize(nil)
     end
 
+    it 'returns nil if provided with empty string' do
+      assert_equal nil, @type.serialize('')
+    end
+
     it 'returns a MySQLBinUUID::Type::Data with stripped values if provided with a UUID' do
       uuid = "3511f33f-3c93-4806-9846-52b4a7618298"
 


### PR DESCRIPTION
Nested attributes are passed in with an empty string as an id. Attempting to serialize an empty string causes an `InvalidUUID`

Using `blank?` instead of `nil?` skips the serialization and thus the `InvalidUUID`