### PR TITLE
Include Rails 7.0.3 in CI, drop unsupported Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"
@@ -24,14 +23,6 @@ jobs:
           - "7.0.2"
           - "7.0.3"
         exclude:
-          - ruby-version: "2.6"
-            rails-version: "7.0.0"
-          - ruby-version: "2.6"
-            rails-version: "7.0.1"
-          - ruby-version: "2.6"
-            rails-version: "7.0.2"
-          - ruby-version: "2.6"
-            rails-version: "7.0.3"
           - ruby-version: "3.0"
             rails-version: "5.2.8"
           - ruby-version: "3.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
             rails-version: "7.0.2"
           - ruby-version: "2.6"
             rails-version: "7.0.3"
-#           - ruby-version: "3.0"
-#             rails-version: "5.2.7.1"
-#           - ruby-version: "3.1"
-#             rails-version: "5.2.7.1"
+          - ruby-version: "3.0"
+            rails-version: "5.2.8"
+          - ruby-version: "3.1"
+            rails-version: "5.2.8"
           - ruby-version: "3.1"
             rails-version: "7.0.0" # See fixed Ruby 3.1 <> Rails 7.0.0 incompatibility: https://github.com/rails/rails/releases/tag/v7.0.1
     name: tests (ruby-${{ matrix.ruby-version }}, rails-${{ matrix.rails-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
           - "3.0"
           - "3.1"
         rails-version:
-          - "5.2.7.1"
-          - "6.1.5.1"
+          - "5.2.8"
+          - "6.1.6"
           - "7.0.0"
           - "7.0.1"
           - "7.0.2"
+          - "7.0.3"
         exclude:
           - ruby-version: "2.6"
             rails-version: "7.0.0"
@@ -29,10 +30,12 @@ jobs:
             rails-version: "7.0.1"
           - ruby-version: "2.6"
             rails-version: "7.0.2"
-          - ruby-version: "3.0"
-            rails-version: "5.2.7.1"
-          - ruby-version: "3.1"
-            rails-version: "5.2.7.1"
+          - ruby-version: "2.6"
+            rails-version: "7.0.3"
+#           - ruby-version: "3.0"
+#             rails-version: "5.2.7.1"
+#           - ruby-version: "3.1"
+#             rails-version: "5.2.7.1"
           - ruby-version: "3.1"
             rails-version: "7.0.0" # See fixed Ruby 3.1 <> Rails 7.0.0 incompatibility: https://github.com/rails/rails/releases/tag/v7.0.1
     name: tests (ruby-${{ matrix.ruby-version }}, rails-${{ matrix.rails-version }})

--- a/mysql-binuuid-rails.gemspec
+++ b/mysql-binuuid-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["**/*"].select { |f| File.file?(f) }
                           .reject { |f| f.end_with?(".gem") }
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_runtime_dependency "activerecord", ENV["RAILS_VERSION"] || ">= 5"
 


### PR DESCRIPTION
Ruby 2.6 is no longer supported.