### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: push
+on: [ push, pull_request ]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
         rails-version:
           - "5.2.8"
           - "6.1.6"
@@ -23,12 +24,11 @@ jobs:
           - "7.0.2"
           - "7.0.3"
         exclude:
-          - ruby-version: "3.0"
-            rails-version: "5.2.8"
-          - ruby-version: "3.1"
-            rails-version: "5.2.8"
-          - ruby-version: "3.1"
-            rails-version: "7.0.0" # See fixed Ruby 3.1 <> Rails 7.0.0 incompatibility: https://github.com/rails/rails/releases/tag/v7.0.1
+          - { ruby-version: "3.0", rails-version: "5.2.8" }
+          - { ruby-version: "3.1", rails-version: "5.2.8" }
+          - { ruby-version: "3.1", rails-version: "7.0.0" } # See fixed Ruby 3.1 <> Rails 7.0.0 incompatibility: https://github.com/rails/rails/releases/tag/v7.0.1
+          - { ruby-version: "3.2", rails-version: "5.2.8" }
+          - { ruby-version: "3.2", rails-version: "7.0.0" }
     name: tests (ruby-${{ matrix.ruby-version }}, rails-${{ matrix.rails-version }})
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the CI build matrix and ensure the project is compatible.