### PR TITLE
Move unpack to deserialize

### DIFF
--- a/lib/mysql-binuuid/type.rb
+++ b/lib/mysql-binuuid/type.rb
@@ -45,7 +45,6 @@ module MySQLBinUUID
       else
         super # foward to cast(value)
       end
-      super
     end
 
     # We're inheriting from the Binary type since ActiveRecord in that case


### PR DESCRIPTION
We need to unpack the binary when AR reads it from the database. That is the purpose of the method `deserialize`. That way, the cast method does not need to guess in which context it is called. That makes your code more straightforward to reason about.