### PR TITLE
CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
         rails-version:
           - "5.2.8"
           - "6.1.6"
@@ -30,6 +31,8 @@ jobs:
           - { ruby-version: "3.1", rails-version: "7.0.0" } # See fixed Ruby 3.1 <> Rails 7.0.0 incompatibility: https://github.com/rails/rails/releases/tag/v7.0.1
           - { ruby-version: "3.2", rails-version: "5.2.8" }
           - { ruby-version: "3.2", rails-version: "7.0.0" }
+          - { ruby-version: "3.3", rails-version: "5.2.8" }
+          - { ruby-version: "3.3", rails-version: "7.0.0" }
     name: tests (ruby-${{ matrix.ruby-version }}, rails-${{ matrix.rails-version }})
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Ruby 3.3 has [been released](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)! Let's add it to the CI build matrix for confidence in compatibility.