### PR TITLE
Simplify CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,33 +11,18 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ruby-version:
-          - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
-          - "3.3"
-        rails-version:
-          - "5.2.8"
-          - "6.1.6"
-          - "7.0.0"
-          - "7.0.1"
-          - "7.0.2"
-          - "7.0.3.1"
-          - "7.0.4.1"
-        exclude:
-          - { ruby-version: "3.0", rails-version: "5.2.8" }
-          - { ruby-version: "3.1", rails-version: "5.2.8" }
-          - { ruby-version: "3.1", rails-version: "7.0.0" } # See fixed Ruby 3.1 <> Rails 7.0.0 incompatibility: https://github.com/rails/rails/releases/tag/v7.0.1
-          - { ruby-version: "3.2", rails-version: "5.2.8" }
-          - { ruby-version: "3.2", rails-version: "7.0.0" }
-          - { ruby-version: "3.3", rails-version: "5.2.8" }
-          - { ruby-version: "3.3", rails-version: "7.0.0" }
-    name: tests (ruby-${{ matrix.ruby-version }}, rails-${{ matrix.rails-version }})
+        ruby: [ "3.3", "3.2", "3.1", "3.0" ]
+        rails: [ "7.0", "6.1"]
+        include:
+          - { ruby: "2.7", rails: "6.0" }
+          - { ruby: "2.7", rails: "5.2" }
+          - { ruby: "2.7", rails: "5.1" }
+          - { ruby: "2.7", rails: "5.0" }
+    name: "tests (Ruby: ${{ matrix.ruby }}, Rails: ${{ matrix.rails }})"
     runs-on: ubuntu-latest
     env:
       MYSQL_HOST: '127.0.0.1'
-      RAILS_VERSION: ${{ matrix.rails-version }}
+      BUNDLE_GEMFILE: test/gemfiles/rails-${{ matrix.rails }}.gemfile
     services:
       mysql:
         image: mysql:8
@@ -47,10 +32,9 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
         options: --health-cmd "mysqladmin ping" --health-interval 5s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: ${{ matrix.ruby-version }}
-      - run: bundle update activerecord
+          ruby-version: ${{ matrix.ruby }}
       - run: bundle exec rake

--- a/mysql-binuuid-rails.gemspec
+++ b/mysql-binuuid-rails.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_runtime_dependency "activerecord", ENV["RAILS_VERSION"] || ">= 5"
+  spec.add_runtime_dependency "activerecord", ">= 5"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mysql2"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "rails", ENV["RAILS_VERSION"] || ">= 5" # required for a console
+  spec.add_development_dependency "rails", ">= 5" # required for a console
 end

--- a/test/gemfiles/rails-5.0.gemfile
+++ b/test/gemfiles/rails-5.0.gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec path: "../.."
+gem "activerecord", "~> 5.0.0"

--- a/test/gemfiles/rails-5.1.gemfile
+++ b/test/gemfiles/rails-5.1.gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec path: "../.."
+gem "activerecord", "~> 5.1.0"

--- a/test/gemfiles/rails-5.2.gemfile
+++ b/test/gemfiles/rails-5.2.gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec path: "../.."
+gem "activerecord", "~> 5.2.0"

--- a/test/gemfiles/rails-6.0.gemfile
+++ b/test/gemfiles/rails-6.0.gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec path: "../.."
+gem "activerecord", "~> 6.0.0"

--- a/test/gemfiles/rails-6.1.gemfile
+++ b/test/gemfiles/rails-6.1.gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec path: "../.."
+gem "activerecord", "~> 6.1.0"

--- a/test/gemfiles/rails-7.0.gemfile
+++ b/test/gemfiles/rails-7.0.gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec path: "../.."
+gem "activerecord", "~> 7.0.0"


### PR DESCRIPTION
Simplify the CI matrix: test against only the latest patch release for each significant Rails version.